### PR TITLE
Add base types

### DIFF
--- a/ghwht/__init__.py
+++ b/ghwht/__init__.py
@@ -1,0 +1,10 @@
+"""
+    ghwht
+    ~~~~
+
+    Type definitons for GitHub webhooks.
+"""
+from . import meta
+
+__version__ = meta.VERSION
+__author__ = meta.AUTHOR

--- a/ghwht/__init__.py
+++ b/ghwht/__init__.py
@@ -1,6 +1,6 @@
 """
     ghwht
-    ~~~~
+    ~~~~~
 
     Type definitons for GitHub webhooks.
 """

--- a/ghwht/hooks/__init__.py
+++ b/ghwht/hooks/__init__.py
@@ -1,0 +1,6 @@
+"""
+    ghwht/hooks
+    ~~~~~~~~~~~
+
+    Contains modules for each type of webhook event.
+"""

--- a/ghwht/hooks/base.py
+++ b/ghwht/hooks/base.py
@@ -1,0 +1,94 @@
+"""
+    ghwht/hooks/base
+    ~~~~~~~~~~~~~~~~
+
+    Contains types generic to all GitHub webhooks.
+"""
+import abc
+import enum
+
+from typing import ClassVar, Generic, Optional, TypeVar
+from uuid import UUID
+
+from pydantic import dataclasses, generics
+
+from . import common
+
+
+class EventName(enum.Enum):
+    """
+    Enumeration for all known GitHub webhook events.
+    """
+    Installation = 'installation'
+    Ping = 'ping'
+
+
+class Action(enum.Enum):
+    """
+    Represents a Github event action.
+
+    This is a marker class so we can apply inheritance constraints on generic
+    types and can never implement actual enumeration values. Abstract in the strictest sense.
+    """
+
+
+# Generic type var for types derived from :class:`~ghwht.hooks.base.Action`.
+AT = TypeVar('AT', bound=Action)
+
+
+class Payload(metaclass=abc.ABCMeta):
+    """
+    Represents a Github event payload.
+
+    This is a marker class so we can apply inheritance constraints on generic
+    types and shouldn't implement any fields. Abstract in the strictest sense.
+    """
+
+
+@dataclasses.dataclass
+class EmptyPayload(Payload):
+    """
+    Represents an empty Github event payload.
+    """
+
+
+@dataclasses.dataclass
+class StandardPayload(Payload):
+    """
+    Represents a standard Github event payload.
+
+    This contains commonly found information about the context that generated the webhook event.
+    """
+    installation: Optional[common.Installation]
+    organization: Optional[common.Organization]
+    repository: Optional[common.Repository]
+    sender: Optional[common.Sender]
+
+
+# Generic type var for types derived from :class:`~ghwht.hooks.base.Payload`.
+PT = TypeVar('PT', bound=Payload)
+
+
+class Event(generics.GenericModel, Generic[AT, PT]):
+    """
+    Represents an abstract Github webhook event.
+
+    All known GitHub webhook events should derive from this class and define the
+    event 'name' that they should be parsed from.
+
+    Event models encapsulate information that comes in both the webhook request payload
+    and HTTP headers.
+    """
+    name: ClassVar[EventName]
+
+    delivery_id: UUID
+    hook_id: int
+    action: Optional[AT]
+    payload: PT
+
+    @property
+    def installation_id(self):
+        return getattr(getattr(self.payload, 'installation', None), 'id', None)
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/ghwht/meta.py
+++ b/ghwht/meta.py
@@ -5,8 +5,8 @@
     Contains information about the package.
 """
 AUTHOR_NAME = 'Andrew Hawker'
-AUTHOR_EMAIL = 'andrew.r.hawker@gmail.com'
-AUTHOR = 'Andrew Hawker <andrew.r.hawker@gmail.com>'
+AUTHOR_EMAIL = 'andrew@flyingdice.dev'
+AUTHOR = 'Andrew Hawker <andrew@flyingdice.dev>'
 NAME = 'ghwht'
 VERSION = '0.0.1'
 TAGLINE = 'Type definitions for GitHub webhooks.'

--- a/ghwht/meta.py
+++ b/ghwht/meta.py
@@ -1,0 +1,14 @@
+"""
+    ghwht/meta
+    ~~~~~~~~~
+
+    Contains information about the package.
+"""
+AUTHOR_NAME = 'Andrew Hawker'
+AUTHOR_EMAIL = 'andrew.r.hawker@gmail.com'
+AUTHOR = 'Andrew Hawker <andrew.r.hawker@gmail.com>'
+NAME = 'ghwht'
+VERSION = '0.0.1'
+TAGLINE = 'Type definitions for GitHub webhooks.'
+URL = 'https://github.com/flyingdice/github-webhook-types'
+LICENSE = 'Apache 2.0'


### PR DESCRIPTION
**Status:** Ready

If merged, this PR adds the `hooks/base.py` module that contains the base/abstract classes for building all other webhook event types.