### PR TITLE
Add ID type and export public API

### DIFF
--- a/ghwht/__init__.py
+++ b/ghwht/__init__.py
@@ -4,7 +4,15 @@
 
     Type definitons for GitHub webhooks.
 """
-from . import meta
+from . import api, meta
 
-__version__ = meta.VERSION
+new = api.new
+Event = api.Event
+EventName = api.EventName
+EventT = api.EventT
+ID = api.ID
+
+
+__all__ = api.__all__
 __author__ = meta.AUTHOR
+__version__ = meta.VERSION

--- a/ghwht/api.py
+++ b/ghwht/api.py
@@ -1,0 +1,51 @@
+"""
+    ghwht/api
+    ~~~~~~~~~
+
+    Defines the public API for the `ghwht` package.
+"""
+from typing import Optional
+
+from . import hooks
+
+__all__ = ['new', 'Event', 'EventName', 'EventT', 'ID']
+
+# Export common base types.
+Event = hooks.Event
+EventName = hooks.EventName
+EventT = hooks.EventT
+ID = hooks.ID
+
+
+def new(delivery_id: str,
+        event_name: str,
+        hook_id: str,
+        action: Optional[str],
+        payload: dict) -> hooks.EventT:
+    """
+    Create an event instance for the given data.
+
+    The type of Event returned is determined by the event name/action of the request.
+
+    :param delivery_id: UUID of the delivery
+    :param event_name: Name of the event
+    :param hook_id: ID of the webhook
+    :param action: Action of the event
+    :param payload: Event data payload
+    :return: Event
+    """
+    name = hooks.EventName(event_name)
+
+    id_cls = hooks.NAME_TO_ID[name]
+    event_cls = hooks.NAME_TO_EVENT[name]
+
+    return event_cls(
+        id=id_cls(
+            event_name=name,
+            action=action
+        ),
+        delivery_id=delivery_id,
+        hook_id=int(hook_id),
+        payload=payload
+    )
+

--- a/ghwht/hooks/__init__.py
+++ b/ghwht/hooks/__init__.py
@@ -4,3 +4,39 @@
 
     Contains modules for each type of webhook event.
 """
+from typing import Dict, Type
+
+from . import base, installation, ping, pull_request, repository
+
+__all__ = ['NAME_TO_EVENT', 'Event', 'EventName', 'EventT', 'ID']
+
+# Alias to simplify imports.
+Event = base.Event
+EventName = base.EventName
+EventT = base.EventT
+ID = base.ID
+IDT = base.IDT
+
+
+def hooks_modules():
+    """
+    Generator function that yields all registered webhook event modules.
+    """
+    for module in (installation, ping, pull_request, repository):
+        yield module
+
+
+# Lookup table that maps event names to their appropriate identifier type.
+# Ex: 'issues' -> ghwht.hooks.issues.Identifier.
+NAME_TO_ID: Dict[EventName, Type[IDT]] = dict(
+    (module.Name, module.ID)
+    for module in hooks_modules()
+)
+
+
+# Lookup table that maps event names to their appropriate type.
+# Ex: 'issues' -> ghwht.hooks.issues.Event.
+NAME_TO_EVENT: Dict[EventName, Type[EventT]] = dict(
+    (module.Name, module.Event)
+    for module in hooks_modules()
+)

--- a/ghwht/hooks/__init__.py
+++ b/ghwht/hooks/__init__.py
@@ -22,7 +22,7 @@ def hooks_modules():
     """
     Generator function that yields all registered webhook event modules.
     """
-    for module in (installation, ping, pull_request, repository):
+    for module in (ping,):
         yield module
 
 

--- a/ghwht/hooks/ping.py
+++ b/ghwht/hooks/ping.py
@@ -35,11 +35,12 @@ class Hook:
 
 
 @dataclasses.dataclass
-class Payload(base.Payload):
+class Payload(base.EmptyPayload):
     hook: Hook
     hook_id: int
     zen: str
 
 
-class Event(base.Event[base.Action, Payload]):
-    name = base.EventName.Ping
+Name = base.EventName.Ping
+ID = base.ID[base.Action]
+Event = base.Event[ID, Payload]


### PR DESCRIPTION
**Status:** Ready

If merged, this PR adds the `ID` type. This encapsulates the event name and optional action and handles proper str conversion, e.g `'issues.created'`.

The public API exposes a number of type definitions but is mainly focused around the `new` method. This takes primitive types that are sent in each webhook event. Extract of these values from an HTTP request is framework dependent, thus, outside of the scope of this project.