### PR TITLE
Add 'public' webhook event

### DIFF
--- a/ghwht/hooks/__init__.py
+++ b/ghwht/hooks/__init__.py
@@ -7,7 +7,7 @@
 from typing import Dict, Type
 
 from . import (base, check_run, check_suite, installation,
-               ping, pull_request, push, release, repository)
+               ping, public, pull_request, push, release, repository)
 
 __all__ = ['NAME_TO_EVENT', 'Event', 'EventName', 'EventT', 'ID']
 
@@ -24,7 +24,7 @@ def hooks_modules():
     Generator function that yields all registered webhook event modules.
     """
     yield from (check_run, check_suite, installation,
-                ping, pull_request, push, release, repository)
+                ping, public, pull_request, push, release, repository)
 
 
 # Lookup table that maps event names to their appropriate identifier type.

--- a/ghwht/hooks/public.py
+++ b/ghwht/hooks/public.py
@@ -1,0 +1,28 @@
+"""
+    ghwht/hooks/public
+    ~~~~~~~~~~~~~~~~~~
+
+    Contains types for the 'public' webhook.
+
+    https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#public
+"""
+from typing import Optional
+
+from pydantic import dataclasses
+
+from . import base, common
+
+
+@dataclasses.dataclass
+class Payload(base.Payload):
+    repository: common.Repository
+    sender: common.Sender
+
+    installation: Optional[common.Installation] = None
+    organization: Optional[common.Organization] = None
+
+
+Action = base.Action
+Name = base.EventName.Public
+ID = base.ID[Action]
+Event = base.Event[ID, Payload]


### PR DESCRIPTION
**Status:** Ready

If merged, adds support for the `'public'` webhook event.

I'm not sure if this is even fired anymore vs. the publicized/privatized repository events but we'll define it anyways.