### PR TITLE
Fix Actions

### DIFF
--- a/ghwht/hooks/installation.py
+++ b/ghwht/hooks/installation.py
@@ -18,6 +18,7 @@ from . import base, common
 class Action(str, enum.Enum):
     Created = 'created'
     Deleted = 'deleted'
+    NewPermissionsAccepted = 'new_permissions_accepted'
     Suspended = 'suspend'
     Unsuspend = 'unsuspend'
 
@@ -55,9 +56,10 @@ class Repository:
 @dataclasses.dataclass
 class Payload(base.Payload):
     installation: Installation
-    repositories: List[Repository]
-    requester: Optional[str]
     sender: common.Sender
+
+    repositories: List[Repository] = None
+    requester: Optional[str] = None
 
 
 Name = base.EventName.Installation

--- a/ghwht/hooks/push.py
+++ b/ghwht/hooks/push.py
@@ -49,16 +49,45 @@ class Organization:
 
 
 @dataclasses.dataclass
+class Author:
+    email: str
+    name: str
+    username: str
+
+
+@dataclasses.dataclass
+class Committer:
+    email: str
+    name: str
+    username: str
+
+
+@dataclasses.dataclass
+class Commit:
+    added: List[str]
+    author: Author
+    committer: Committer
+    distinct: bool
+    id: str
+    message: str
+    modified: List[str]
+    removed: List[str]
+    tree_id: str
+    timestamp: datetime
+    url: HttpUrl
+
+
+@dataclasses.dataclass
 class Payload(base.Payload):
     after: str
-    base_ref: Optional[common.Commit]
+    base_ref: Optional[str]
     before: str
-    commits: List[common.Commit]
+    commits: List[Commit]
     compare: str
     created: bool
     deleted: bool
     forced: bool
-    head_commit: Optional[common.Commit]
+    head_commit: Optional[Commit]
     pusher: common.Pusher
     ref: str
     repository: common.Repository


### PR DESCRIPTION
**Status:** Ready

If merged, this PR fixes the `'installation'` and `'push`' events. It now supports the `'new_permissions_accepted'` installation action and `'push`' events use the proper models for things like commit, author, pusher, etc.